### PR TITLE
Add --rm flag to docker run

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 docker pull battlecode/battlecode-2018
 
-docker run -it --privileged -p 16147:16147 -p 6147:6147 -v $PWD:/player battlecode/battlecode-2018
+docker run -it --rm --privileged -p 16147:16147 -p 6147:6147 -v $PWD:/player battlecode/battlecode-2018


### PR DESCRIPTION
Without the rm flag a large number of stoped docker containers will be present on the system after running this script a number of times. Add the --rm flag to prevent this.