### PR TITLE
Remove python 3.6 string formatting

### DIFF
--- a/battlecode-manager/battlecode_cli.py
+++ b/battlecode-manager/battlecode_cli.py
@@ -83,7 +83,7 @@ def run_game(game, dockers, args, sock_file):
             team = 'blue'
         else:
             team = 'red'
-        name = f'[{planet}:{team}]'
+        name = '[{}:{}]'.format(planet, team)
         logger = Logger(name)
         docker_inst.stream_logs(line_action=logger)
         player_['logger'] = logger

--- a/battlecode-manager/server.py
+++ b/battlecode-manager/server.py
@@ -387,7 +387,7 @@ def create_receive_handler(game: Game, dockers, use_docker: bool,
             else:
                 logged_in = "false"
 
-            message = f'{{"logged_in":{logged_in},"client_id":"{self.client_id}","error":{error},"message":{state_diff}}}'
+            message = '{{"logged_in":{},"client_id":"{}","error":{},"message":{}}}'.format(logged_in, self.client_id, error, state_diff);
             return message
 
         def player_handler(self):


### PR DESCRIPTION
This seems to be all it takes to make the manager work with python 3.5 and perhaps lower.